### PR TITLE
[Proposal 1]: Change bootstrapping period & rewards ratio

### DIFF
--- a/bsc/contracts/Constants.sol
+++ b/bsc/contracts/Constants.sol
@@ -24,7 +24,7 @@ library Constants {
     uint256 private constant CHAIN_ID = 56; // BSC 
 
     /* Bootstrapping */
-    uint256 private constant BOOTSTRAPPING_PERIOD = 180; // 180 epochs
+    uint256 private constant BOOTSTRAPPING_PERIOD = 60; // 60 epochs
     uint256 private constant BOOTSTRAPPING_PRICE = 11e17; // 1.10 USDC
     uint256 private constant BOOTSTRAPPING_SUPPLY_CHANGE_LIMIT = 10e16; // 10%
 
@@ -55,7 +55,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 1e19; // 10 SPAD
+    uint256 private constant ADVANCE_INCENTIVE = 5e18; // 5 SPAD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 30; // 30 epochs
 
     /* Pool */
@@ -68,7 +68,7 @@ library Constants {
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
-    uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
+    uint256 private constant ORACLE_POOL_RATIO = 5550; // 55.5%
     uint256 private constant TREASURY_RATIO = 450; // 4.5%
 
     /* Address */

--- a/bsc/contracts/dao/Comptroller.sol
+++ b/bsc/contracts/dao/Comptroller.sol
@@ -75,7 +75,7 @@ contract Comptroller is Setters {
     function increaseSupply(uint256 newSupply) internal returns (uint256, uint256, uint256) {
         (uint256 newRedeemable, uint256 lessDebt, uint256 poolReward) = (0, 0, 0);
         // 0-a. Pay out to Pool
-        poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(100);
+        poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(10000);
         mintToPool(poolReward);
 
         // 0-b. Pay out to Treasury

--- a/bsc/contracts/dao/Implementation.sol
+++ b/bsc/contracts/dao/Implementation.sol
@@ -32,7 +32,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function initialize() initializer public {
         // committer reward:
-        mintToAccount(msg.sender, 2000e18); // 2000 SPAD to committer
+        mintToAccount(msg.sender, 10e18); // 10 SPAD to committer
     }
 
     function advance() external incentivized {

--- a/eth/contracts/Constants.sol
+++ b/eth/contracts/Constants.sol
@@ -24,7 +24,7 @@ library Constants {
     uint256 private constant CHAIN_ID = 1; // MAINNET 
 
     /* Bootstrapping */
-    uint256 private constant BOOTSTRAPPING_PERIOD = 180; // 180 epochs
+    uint256 private constant BOOTSTRAPPING_PERIOD = 60; // 60 epochs
     uint256 private constant BOOTSTRAPPING_PRICE = 11e17; // 1.10 USDC
     uint256 private constant BOOTSTRAPPING_SUPPLY_CHANGE_LIMIT = 10e16; // 10%
 
@@ -55,7 +55,7 @@ library Constants {
     uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 5e19; // 50 SPAD
+    uint256 private constant ADVANCE_INCENTIVE = 10e18; // 10 SPAD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 30; // 30 epochs
 
     /* Pool */
@@ -68,7 +68,7 @@ library Constants {
     /* Regulator */
     uint256 private constant SUPPLY_CHANGE_LIMIT = 3e16; // 3%
     uint256 private constant COUPON_SUPPLY_CHANGE_LIMIT = 6e16; // 6%
-    uint256 private constant ORACLE_POOL_RATIO = 20; // 20%
+    uint256 private constant ORACLE_POOL_RATIO = 5550; // 55.5%
     uint256 private constant TREASURY_RATIO = 450; // 4.5%
 
     /* Address */

--- a/eth/contracts/dao/Comptroller.sol
+++ b/eth/contracts/dao/Comptroller.sol
@@ -75,7 +75,7 @@ contract Comptroller is Setters {
     function increaseSupply(uint256 newSupply) internal returns (uint256, uint256, uint256) {
         (uint256 newRedeemable, uint256 lessDebt, uint256 poolReward) = (0, 0, 0);
         // 0-a. Pay out to Pool
-        poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(100);
+        poolReward = newSupply.mul(Constants.getOraclePoolRatio()).div(10000);
         mintToPool(poolReward);
 
         // 0-b. Pay out to Treasury

--- a/eth/contracts/dao/Implementation.sol
+++ b/eth/contracts/dao/Implementation.sol
@@ -32,7 +32,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function initialize() initializer public {
         // committer reward:
-        mintToAccount(msg.sender, 2000e18); // 2000 SPAD to committer
+        mintToAccount(msg.sender, 100e18); // 100 SPAD to committer
     }
 
     function advance() external incentivized {


### PR DESCRIPTION
# [Proposal 1]: Change bootstrapping period & rewards ratio

## Summary

- **SIP-1**: Shorten bootstrapping period to `60 epochs`.

- **SIP-2**: Change rewards DAO `40%` / LP `55.5%`.  

- **Addictional**: Change `advance()` rewards ETH to `10 SPAD`, BSC to `5 SPAD`.

## Description

#### SIP-1

Currently, Bootstrapping period is `180 epochs` when ending period SPAD supply will growth to 56billion. The goal need to decrease total supply when ending period. The communities decided to shorten bootstrapping period to `60 epochs` decrease ending supply to 600k.

#### SIP-2

With increase more liquidity, The communities decided to adjust rewards ration from DAO `75.5%` / LP `20%` to DAO `40%` / LP `55.5%`.

#### Addictional
Currently, we encounter with `advance()` rewards dump. With the reason, we will adjust `advance()` rewards from ETH `50 SPAD`,  BSC `10 SPAD` to ETH `10 SPAD`,  BSC `5 SPAD`.

## Rewards

-   Rewards  `committer`  with `10 SPAD` on BSC,  `100 SPAD` on ETH (spend gas for deploy and commit)

## Tracking

Status: Pre-proposal