### PR TITLE
[Proposal 2]: Decrease governance period & increase advance incentive on ETH

### DIFF
--- a/bsc/contracts/Constants.sol
+++ b/bsc/contracts/Constants.sol
@@ -47,12 +47,12 @@ library Constants {
     uint256 private constant EPOCH_PERIOD = 14400; // 4 hrs
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 18; // 18 epochs
+    uint256 private constant GOVERNANCE_PERIOD = 6; // 6 epochs
     uint256 private constant GOVERNANCE_EXPIRATION = 4; // 4 + 1 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
-    uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
+    uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 4; // 4 epochs
 
     /* DAO */
     uint256 private constant ADVANCE_INCENTIVE = 5e18; // 5 SPAD

--- a/bsc/contracts/dao/Implementation.sol
+++ b/bsc/contracts/dao/Implementation.sol
@@ -32,7 +32,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function initialize() initializer public {
         // committer reward:
-        mintToAccount(msg.sender, 10e18); // 10 SPAD to committer
+        mintToAccount(msg.sender, 10e18); // 10 SPAD to Deployer & Committer
     }
 
     function advance() external incentivized {

--- a/eth/contracts/Constants.sol
+++ b/eth/contracts/Constants.sol
@@ -47,15 +47,15 @@ library Constants {
     uint256 private constant EPOCH_PERIOD = 14400; // 4 hrs
 
     /* Governance */
-    uint256 private constant GOVERNANCE_PERIOD = 18; // 18 epochs
+    uint256 private constant GOVERNANCE_PERIOD = 6; // 6 epochs
     uint256 private constant GOVERNANCE_EXPIRATION = 4; // 4 + 1 epochs
     uint256 private constant GOVERNANCE_QUORUM = 20e16; // 20%
     uint256 private constant GOVERNANCE_PROPOSAL_THRESHOLD = 5e15; // 0.5%
     uint256 private constant GOVERNANCE_SUPER_MAJORITY = 66e16; // 66%
-    uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 12; // 12 epochs
+    uint256 private constant GOVERNANCE_EMERGENCY_DELAY = 4; // 4 epochs
 
     /* DAO */
-    uint256 private constant ADVANCE_INCENTIVE = 10e18; // 10 SPAD
+    uint256 private constant ADVANCE_INCENTIVE = 100e18; // 100 SPAD
     uint256 private constant DAO_EXIT_LOCKUP_EPOCHS = 30; // 30 epochs
 
     /* Pool */

--- a/eth/contracts/dao/Implementation.sol
+++ b/eth/contracts/dao/Implementation.sol
@@ -32,7 +32,7 @@ contract Implementation is State, Bonding, Market, Regulator, Govern {
 
     function initialize() initializer public {
         // committer reward:
-        mintToAccount(msg.sender, 100e18); // 100 SPAD to committer
+        mintToAccount(msg.sender, 200e18); // 200 SPAD to Deployer & Committer
     }
 
     function advance() external incentivized {


### PR DESCRIPTION
# [Proposal 2]: Decrease governance period & increase advance incentive for ETH

## Summary

- **SIP-3**: Decrease governance period from `18 epochs` to `6 epochs` and increase advance incentive on ETH chains to `100 SPAD`.

## Rewards

-   Rewards  `deployer + committer`  with `10 SPAD` on BSC,  `200 SPAD` on ETH (spend gas for deploy and commit)

## Tracking

Status: Pre-proposal